### PR TITLE
Adding support for custom serializer settings

### DIFF
--- a/src/Sequin/Infrastructure/JsonDeserializerCommandFactory.cs
+++ b/src/Sequin/Infrastructure/JsonDeserializerCommandFactory.cs
@@ -9,6 +9,15 @@
 
     public class JsonDeserializerCommandFactory : ICommandFactory
     {
+        private readonly JsonSerializerSettings serializerSettings;
+
+        public JsonDeserializerCommandFactory() : this(new JsonSerializerSettings()) { }
+
+        public JsonDeserializerCommandFactory(JsonSerializerSettings serializerSettings)
+        {
+            this.serializerSettings = serializerSettings;
+        }
+
         public object Create(Type commandType, IDictionary<string, object> environment)
         {
             var request = new OwinRequest(environment);
@@ -17,7 +26,7 @@
                 var requestBody = streamReader.ReadToEnd();
                 try
                 {
-                    var command = Convert.ChangeType(JsonConvert.DeserializeObject(requestBody, commandType), commandType);
+                    var command = Convert.ChangeType(JsonConvert.DeserializeObject(requestBody, commandType, serializerSettings), commandType);
                     return command;
                 }
                 catch (JsonReaderException ex)

--- a/tests/Sequin.Integration/Features/JsonDeserializerCommandFactoryFeature.cs
+++ b/tests/Sequin.Integration/Features/JsonDeserializerCommandFactoryFeature.cs
@@ -1,0 +1,78 @@
+﻿namespace Sequin.Integration.Features
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Core;
+    using Extensions;
+    using FluentAssertions;
+    using Infrastructure;
+    using Microsoft.Owin.Testing;
+    using Newtonsoft.Json;
+    using Xbehave;
+
+    public class JsonDeserializerCommandFactoryFeature
+    {
+        private CommandTrackingPostProcessor postProcessor;
+
+        [Background]
+        public void Background()
+        {
+            postProcessor = new CommandTrackingPostProcessor();
+        }
+
+        [Scenario]
+        public void CustomisableSerializerSettings(TestServer server, string commandName, string command, HttpResponseMessage response)
+        {
+            "Given I have custom serializer settings"
+                .Given(() =>
+                {
+                    var serializerSettings = new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore};
+
+                    server = TestServer.Create(app =>
+                    {
+                        app.UseSequin(new SequinOptions
+                        {
+                            CommandFactory = new JsonDeserializerCommandFactory(serializerSettings),
+                            PostProcessor = postProcessor
+                        });
+                    });
+                });
+
+            "And I have a command which requires these settings"
+                .And(() =>
+                {
+                    commandName = "TestCommand";
+                    command = "{A:null}";
+                });
+
+            "When I issue an HTTP request"
+                .When(() =>
+                {
+                    response = server.PutCommand("/commands", commandName, command);
+                });
+
+            "Then the command should have been executed"
+                .Then(() =>
+                {
+                    postProcessor.ExecutedCommands.ContainsKey(commandName).Should().BeTrue();
+
+                    var serializedCommand = postProcessor.ExecutedCommands[commandName];
+                    serializedCommand.Should().Contain(Guid.Empty.ToString());
+                });
+        }
+
+        private class TestCommand
+        {
+            public Guid A { get; set; }
+        }
+
+        private class TestCommandHandler : IHandler<TestCommand>
+        {
+            public Task Handle(TestCommand command)
+            {
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/tests/Sequin.Integration/Sequin.Integration.csproj
+++ b/tests/Sequin.Integration/Sequin.Integration.csproj
@@ -121,6 +121,7 @@
     <Compile Include="FeatureBase.cs" />
     <Compile Include="Features\CommandPipelineFeature.cs" />
     <Compile Include="Features\CommandPostProcessingFeature.cs" />
+    <Compile Include="Features\JsonDeserializerCommandFactoryFeature.cs" />
     <Compile Include="Features\OptionsHttpMethodFeature.cs" />
     <Compile Include="Features\UrlCommandNameResolutionFeature.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes #44

I figured rather than only exposing a way to set JSON.NET converters that providing a way to completely configure the JsonSerializerSettings was most flexible.